### PR TITLE
hotfix for linux + python + musl combo

### DIFF
--- a/port_for/ephemeral.py
+++ b/port_for/ephemeral.py
@@ -30,7 +30,8 @@ def port_ranges():
 
 def _linux_ranges():
     with open('/proc/sys/net/ipv4/ip_local_port_range') as f:
-        low, high = f.read().split()
+        # use readline() instead of read() for linux + musl
+        low, high = f.readline().split()
         return [
             (int(low), int(high))
         ]


### PR DESCRIPTION
Hi @kmike,

I'd like to propose a small change to the `_linux_ranges` function.

We've noticed that linux (4.11.9) + musl + python combo doesn't work well with `procfs` files. The following code in `port-for` [fails miserably](https://travis-ci.org/funbringer/testgres/jobs/253668480#L560):

```python
def _linux_ranges():
    with open('/proc/sys/net/ipv4/ip_local_port_range') as f:
        low, high = f.read().split()
```

since `read()` function calls musl's `fread()` which uses the `readv` syscall, whose implementation for `procfs` seems to be broken:

```bash
python2 -c 'f=open("/proc/sys/net/ipv4/ip_local_port_range");l,h=f.readline().split();print(l);print(h);'
Traceback (most recent call last):

  File "<string>", line 1, in <module>

ValueError: need more than 1 value to unpack
```

Although this issue has nothing to do with your library, we decided to provide a tiny workaround for linux users that would like to use it.

