### PR TITLE
Remove dep on mock, as is part of python-3.6.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,4 @@
 # test runs requirements (versions we'll be testing against) - automatically updated
-mock==4.0.3
-types-mock==4.0.10
 pytest==6.2.5  # tests framework used
 pytest-cov==3.0.0  # coverage reports to verify tests quality
 coverage==6.3.1 # pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ where = src
 tests =
     pytest
     pytest-cov
-    mock
 
 [options.package_data]
 port_for = py.typed

--- a/tests/test_cases.py
+++ b/tests/test_cases.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 import tempfile
-import mock
+from unittest import mock
 import socket
 import os
 from typing import Union, List, Set, Tuple


### PR DESCRIPTION
Change based on request in https://fedoraproject.org/wiki/Changes/DeprecatePythonMock