### PR TITLE
PortType type alias - closes #149

### DIFF
--- a/newsfragments/149.feature.rst
+++ b/newsfragments/149.feature.rst
@@ -1,0 +1,1 @@
+Add `PortType` type alias for easier typing related code

--- a/port_for/api.py
+++ b/port_for/api.py
@@ -134,20 +134,22 @@ def filter_by_type(lst: Iterable, type_of: Type[T]) -> List[T]:
     return [e for e in lst if isinstance(e, type_of)]
 
 
+PortType = Union[
+    str,
+    int,
+    Tuple[int, int],
+    Set[int],
+    List[str],
+    List[int],
+    List[Tuple[int, int]],
+    List[Set[int]],
+    List[Union[Set[int], Tuple[int, int]]],
+    List[Union[str, int, Tuple[int, int], Set[int]]],
+]
+
+
 def get_port(
-    ports: Union[
-        None,
-        str,
-        int,
-        Tuple[int, int],
-        Set[int],
-        List[str],
-        List[int],
-        List[Tuple[int, int]],
-        List[Set[int]],
-        List[Union[Set[int], Tuple[int, int]]],
-        List[Union[str, int, Tuple[int, int], Set[int]]],
-    ],
+    ports: Optional[PortType],
     exclude_ports: Optional[Iterable[int]] = None,
 ) -> Optional[int]:
     """


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number