### PR TITLE
Adds PortType to package __all__

### DIFF
--- a/newsfragments/+b61fb792.feature.rst
+++ b/newsfragments/+b61fb792.feature.rst
@@ -1,0 +1,1 @@
+Adds PortType to package __all__

--- a/port_for/__init__.py
+++ b/port_for/__init__.py
@@ -4,6 +4,7 @@ __version__ = "0.7.2"
 
 from ._ranges import UNASSIGNED_RANGES
 from .api import (
+    PortType,
     available_good_ports,
     available_ports,
     get_port,
@@ -25,5 +26,6 @@ __all__ = (
     "select_random",
     "get_port",
     "PortStore",
+    "PortType",
     "PortForException",
 )


### PR DESCRIPTION
Adds PortType to package __all__.
Wards off people importing `port_for.api.PortType` directly.

Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number