### PR TITLE
Turn off windows pypy tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,6 @@ jobs:
       - tests
     uses: fizyk/actions-reuse/.github/workflows/shared-tests-pytests.yml@v4.4.7
     with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.11"]'
+      python-versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       os: windows-latest
       env: '{"PYTHONTRACEMALLOC": 20}'

--- a/newsfragments/+bc96ba57.misc.rst
+++ b/newsfragments/+bc96ba57.misc.rst
@@ -1,0 +1,1 @@
+Turn off windows pypy tests


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Windows test configuration to verify only CPython versions 3.10 through 3.14, discontinuing PyPy 3.11 testing on Windows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fizyk/port-for/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->