### PR TITLE
Trusted publishing

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,8 +5,24 @@ on:
       - v*
 jobs:
   build:
-    uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@v4.4.6
+    uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@v4.4.7
     with:
-      publish: true
-    secrets:
-      pypi_token: ${{ secrets.pypi_token }}
+      publish: false
+
+  publish:
+    name: Publish Python 🐍 distributions 📦 to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions 📦
+        uses: actions/download-artifact@v4
+        with:
+          name: package
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.0
+        with:
+          verbose: true

--- a/newsfragments/+819b47b4.misc.rst
+++ b/newsfragments/+819b47b4.misc.rst
@@ -1,0 +1,1 @@
+Migrate package publishing step to trusted publishing.


### PR DESCRIPTION
Chore that needs to be done:

* [x] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_numer either from issue tracker or the Pull request number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package publishing workflow with improved security practices for package deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fizyk/port-for/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->