### PR TITLE
Migrate build system to uv_build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,4 +8,6 @@ on:
 
 jobs:
   build:
-    uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@a705c3602adb3ef95f7f4bdf81dcacd3a136d86e # v5.0.0
+    uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@14e008c246b7b8eeab7cb5c543117471fee37310 # v5.1.2
+    with:
+      dependency-manager: uv

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,9 +5,10 @@ on:
       - v*
 jobs:
   build:
-    uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@a705c3602adb3ef95f7f4bdf81dcacd3a136d86e # v5.0.0
+    uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@14e008c246b7b8eeab7cb5c543117471fee37310 # v5.1.2
     with:
       publish: false
+      dependency-manager: uv
 
   publish:
     name: Publish Python 🐍 distributions 📦 to PyPI

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include *.txt
-include *.rst
-recursive-include docs *.txt
-recursive-include scripts *

--- a/newsfragments/+pep639.misc.rst
+++ b/newsfragments/+pep639.misc.rst
@@ -1,0 +1,1 @@
+Adopt PEP 639 license metadata: use the ``license = "MIT"`` SPDX expression and ``license-files`` field, drop the deprecated ``License :: OSI Approved :: MIT License`` classifier.

--- a/newsfragments/+uv-build-backend.feature.rst
+++ b/newsfragments/+uv-build-backend.feature.rst
@@ -1,0 +1,1 @@
+Switch the build backend from ``setuptools`` to ``uv_build``, and build distributions via ``uv build`` in CI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "1.0.0"
 description = "Utility that helps with local TCP ports management. It can find an unused TCP localhost port and remember the association."
 readme = "README.rst"
 keywords = ["port", "posix"]
-license = {file = "LICENSE.txt"}
+license = "MIT"
+license-files = ["LICENSE.txt"]
 authors = [
     {name = "Mikhail Korobov", email = "kmike84@gmail.com"}
 ]
@@ -15,7 +16,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -50,15 +50,13 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools >= 61.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build>=0.11"]
+build-backend = "uv_build"
 
-[tool.setuptools]
-zip-safe = true
-packages = ["port_for"]
-
-[tool.setuptools.package-data]
-port_for = ["py.typed"]
+[tool.uv.build-backend]
+module-name = "port_for"
+module-root = ""
+source-include = ["CHANGES.rst"]
 
 [tool.pytest]
 strict_xfail = true
@@ -71,30 +69,25 @@ single_file=true
 filename="CHANGES.rst"
 issue_format="`#{issue} <https://github.com/fizyk/port-for/issues/{issue}>`__"
 
-[[tool.towncrier.type]]
-directory = "break"
+[tool.towncrier.fragment.break]
 name = "Breaking changes"
 showcontent = true
 
-[[tool.towncrier.type]]
-directory = "depr"
-name = "Deprecations"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "feature"
+[tool.towncrier.fragment.feature]
 name = "Features"
 showcontent = true
 
-[[tool.towncrier.type]]
-directory = "bugfix"
+[tool.towncrier.fragment.bugfix]
 name = "Bugfixes"
 showcontent = true
 
-[[tool.towncrier.type]]
-directory = "misc"
-name = "Miscellaneus"
-showcontent = false
+[tool.towncrier.fragment.depr]
+name = "Deprecations"
+showcontent = true
+
+[tool.towncrier.fragment.misc]
+name = "Miscellaneous"
+showcontent = true
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched project build system to uv and updated CI workflow references.
  * Removed obsolete packaging inclusion directives.

* **Documentation**
  * Standardised licence metadata to PEP 639 (SPDX) and included licence-files.
  * Updated release-note fragment configuration and guidance to reflect the new build/backend recommendations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fizyk/port-for/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->