### PR TITLE
Make build.yml reusable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,10 +5,7 @@ on:
       - v*
 jobs:
   build:
-    uses: fizyk/actions-reuse/.github/workflows/shared-pypi.yml@14e008c246b7b8eeab7cb5c543117471fee37310 # v5.1.2
-    with:
-      publish: false
-      dependency-manager: uv
+    uses: ./.github/workflows/build.yml
 
   publish:
     name: Publish Python 🐍 distributions 📦 to PyPI
@@ -19,11 +16,11 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions 📦
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: package
           path: dist/
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           verbose: true

--- a/newsfragments/+reuse-build-workflow.misc.rst
+++ b/newsfragments/+reuse-build-workflow.misc.rst
@@ -1,0 +1,1 @@
+Reuse the ``build.yml`` workflow in ``pypi.yml`` so the pinned action version and dependency manager live in one place.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated CI workflow usage to reuse a local build workflow and updated action pins for reproducible automation and stable publishing.
* **Documentation**
  * Updated release notes fragment to reflect the new workflow reuse and centralized action/version management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->